### PR TITLE
Instructions and JSON middleware

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -5,7 +5,7 @@
 ;; Build checklist
 ;; 1. Run tests, make sure they're green
 ;; 2. Incr app version in this file
-;; 3. Incr app version package.json
+;; 3. Incr app version in package.json
 ;; 4. Futz with changelog
 ;; 5. Land change PR
 ;; 6. Build frontend release with `yarn release` todo: why does this take 2 stinkin minutes

--- a/docs/misc/low_money_prioritization.md
+++ b/docs/misc/low_money_prioritization.md
@@ -2,7 +2,7 @@ We recognize that people might not even have the small amount of money for the p
 
 To reconcile those facts, we give a low-money but very-high-effort way to get prioritization of your feature. I hope that if you're a moneyed enterprise you might agree that you might want to just pay the money. To be absolutely clear, this is merely an option: the other option is to buy licenses and get prioritization without going through this rigamarole. This is for prioritization of features and bugfixes only. Buy the software if you want the professional edition or enterprise edition features.
 
-We will have a self-instance of Mertonon we also do prioritizations on when the authn and authz is finished and whacked at a bit, but we will always keep this method for those who do not want to deal with the self-instance.
+We will also have a self-instance of Mertonon that we also use to do prioritization on, whenever we get the authn and authz to a decently working state, but we will always keep this method for those who do not want to deal with the self-instance.
 
 # Instructions
 
@@ -19,7 +19,7 @@ Keep a fire extinguisher handy at all times. Do the burning outside in a non-fla
 9. Set the dumpster on fire.
 10. Finish recording the video when the miniature dumpster is mostly ashes.
 11. Edit the montage videos of you making the dumpster and the dumpster fire into one video. Gratis video editing is straightforward enough to find for a task of this simplicity.
-12. Post the video on a public website as a reply to the issue you filed and add an @-mention. Gratis video hosting is straightforward enough to find.
+12. Post a link to the video hosted on a public website as a reply to the issue you filed and add an @-mention. Gratis video hosting is straightforward enough to find.
 
 After a valid video is posted, we will acknowledge and prioritize that feature request because you spent effort in good faith, even if you don't have much money. That said, programmers are feckless people and we are not exceptions, so just because we prioritize it may not mean that it actually gets done fast enough: we will only commit rigorously to deadlines for enterprise customers for consideration.
 
@@ -27,6 +27,6 @@ We may also just say no to the issue overall, hopefully before you go through th
 
 You can ask to prioritize issues other people posted, if you feel like going through all that: just write their Github issue number on the piece of paper.
 
-The video has to be in a public place because we may share it, especially if it's entertaining. So be aware that the video may be shared.
+The video has to be in a public video host because we may share it, especially if it's entertaining. So be aware that the video may be shared.
 
 If you cannot burn things, instead get some containers of water and take the video of you destroying the dumpster by soaking it in water and smooshing it with your hands instead.

--- a/docs/misc/low_money_prioritization.md
+++ b/docs/misc/low_money_prioritization.md
@@ -2,6 +2,8 @@ We recognize that people might not even have the small amount of money for the p
 
 To reconcile those facts, we give a low-money but very-high-effort way to get prioritization of your feature. I hope that if you're a moneyed enterprise you might agree that you might want to just pay the money. To be absolutely clear, this is merely an option: the other option is to buy licenses and get prioritization without going through this rigamarole. This is for prioritization of features and bugfixes only. Buy the software if you want the professional edition or enterprise edition features.
 
+We will have a self-instance of Mertonon we also do prioritizations on when the authn and authz is finished and whacked at a bit, but we will always keep this method for those who do not want to deal with the self-instance.
+
 # Instructions
 
 Keep a fire extinguisher handy at all times. Do the burning outside in a non-flammable setting. If your jurisdiction has a no-burn notice, you should not do this. If there is permitting for burning, get a permit. If your jurisdiction has poor air quality, you should not do this. Generally, follow the laws of your jurisdiction.

--- a/docs/misc/low_money_prioritization.md
+++ b/docs/misc/low_money_prioritization.md
@@ -11,10 +11,10 @@ We will also have a self-instance of Mertonon that we also use to do prioritizat
 Keep a fire extinguisher handy at all times. Do the burning outside in a non-flammable setting. If your jurisdiction has a no-burn notice, you should not do this. If there is permitting for burning, get a permit. If your jurisdiction has poor air quality, you should not do this. Generally, follow the laws of your jurisdiction.
 
 1. Actually file the issue on Github.
-2. Take some montage videos of you making a miniature papier-mâché dumpster about the size of a purse out of flammable materials. Quality of dumpster can be poor, this is not an art contest. Has to be papier-mâché. If you wish to stay anonymous, wear a mask or something.
+2. Take some montage cellphone videos of you making a miniature papier-mâché dumpster about the size of a purse out of flammable materials. Quality of dumpster can be poor, this is not an art contest. Has to be papier-mâché. If you wish to stay anonymous, wear a mask or something.
 3. After making the miniature dumpster, wait for it to be bone dry. Usually takes a day.
 4. Write down the current date, "Mertonon" and the Github issue number of your feature request on a piece of paper.
-5. Start recording video.
+5. Start recording cellphone video again.
 6. Show the piece of paper with the current date and Github issue number and "Mertonon" in the video, making sure it can be read clearly in the video.
 7. Crumple up the piece of paper.
 8. Insert the piece of paper into the miniature dumpster.

--- a/docs/misc/low_money_prioritization.md
+++ b/docs/misc/low_money_prioritization.md
@@ -1,10 +1,12 @@
+# Mertonon Low Money Issue Prioritization
+
 We recognize that people might not even have the small amount of money for the professional edition and still might want some prioritized features or bugfixes. However, free-for-all prioritization cannot be in good faith.
 
 To reconcile those facts, we give a low-money but very-high-effort way to get prioritization of your feature. I hope that if you're a moneyed enterprise you might agree that you might want to just pay the money. To be absolutely clear, this is merely an option: the other option is to buy licenses and get prioritization without going through this rigamarole. This is for prioritization of features and bugfixes only. Buy the software if you want the professional edition or enterprise edition features.
 
 We will also have a self-instance of Mertonon that we also use to do prioritization on, whenever we get the authn and authz to a decently working state, but we will always keep this method for those who do not want to deal with the self-instance.
 
-# Instructions
+## Instructions
 
 Keep a fire extinguisher handy at all times. Do the burning outside in a non-flammable setting. If your jurisdiction has a no-burn notice, you should not do this. If there is permitting for burning, get a permit. If your jurisdiction has poor air quality, you should not do this. Generally, follow the laws of your jurisdiction.
 

--- a/docs/misc/low_money_prioritization.md
+++ b/docs/misc/low_money_prioritization.md
@@ -6,6 +6,15 @@ To reconcile those facts, we give a low-money but very-high-effort way to get pr
 
 We will also have a self-instance of Mertonon that we also use to do prioritization on, whenever we get the authn and authz to a decently working state, but we will always keep this method for those who do not want to deal with the self-instance.
 
+## Materials
+
+1. Cell phone. Presumably you have one already
+2. Bunch of waste paper
+3. Glue to make papier-mâché
+4. Some way of making fire
+5. Some place outside where you can make a fire
+6. Fire extinguisher. You'd better have one already
+
 ## Instructions
 
 Keep a fire extinguisher handy at all times. Do the burning outside in a non-flammable setting. If your jurisdiction has a no-burn notice, you should not do this. If there is permitting for burning, get a permit. If your jurisdiction has poor air quality, you should not do this. Generally, follow the laws of your jurisdiction.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,7 +12,7 @@ Also look at small tasks roadmap
 - Change usage docs and call authn deployed
 
 - FE testing
-- FE user crud, not just admin account anymore
+- FE user crud, not just sole admin account anymore (but every account admin account so far...)
 - More GH actions CI
 - Staring at credit allocation semantics both in docs and program. True conservations, along with property. Whack a profit thing out for real, refactor the competitiveness thing to budget utilization
 - Kick off forward passes every time we change anything

--- a/docs/v0_4_roadmap.md
+++ b/docs/v0_4_roadmap.md
@@ -13,10 +13,11 @@
 - [x] Check intro FE manually again
 - [x] Check login manually
 - [x] Hook login to cookies
+- [x] Sick and tired of manual jsonning of endpoints, figure out the middleware
 
 - [ ] Get intro BE test to work in any db state by hooking it harder to macro somehow
+- [ ] Graph consonance test is being persnickety again, whack it until it stays still
 - [ ] Exception handler that returns 400 instead of 500 if it eats something from validations
-- [ ] Sick and tired of manual jsonning of endpoints, figure out the middleware
 - [ ] Build CI
 - [ ] Changelog
 - [ ] Futz around a bit

--- a/docs/v0_4_roadmap.md
+++ b/docs/v0_4_roadmap.md
@@ -18,7 +18,7 @@
 - [ ] Get intro BE test to work in any db state by hooking it harder to macro somehow
 - [ ] Graph consonance test is being persnickety again, whack it until it stays still
 - [ ] Exception handler that returns 400 instead of 500 if it eats something from validations
-- [ ] Build CI
+- [ ] Build CI (no test, test on my box for now)
 - [ ] Changelog
 - [ ] Futz around a bit
 - [ ] Deploy with new build action

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mertonon",
-  "version": "0.3.17-prealpha",
+  "version": "0.3.commits-prealpha",
   "description": "Neural Organizational Management",
   "repository": {
     "type": "git",

--- a/src/mertonon/api/allocation_cue.clj
+++ b/src/mertonon/api/allocation_cue.clj
@@ -1,12 +1,10 @@
 (ns mertonon.api.allocation-cue
   "API for messages cueing people for allocations"
-  (:require [clojure.data.json :as json]
-            [mertonon.util.io :as uio]))
+  (:require [mertonon.util.io :as uio]))
 
 (defn endpoint []
   {:get  (fn [match]
-           {:status 200 :body (json/write-str
-                                {:cue "How essential to your work is this entity"})})
+           {:status 200 :body {:cue "How essential to your work is this entity"}})
    :name ::allocation-cue})
 
 (defn routes []

--- a/src/mertonon/api/cost_object.clj
+++ b/src/mertonon/api/cost_object.clj
@@ -1,7 +1,6 @@
 (ns mertonon.api.cost-object
   "API for cost objects"
-  (:require [clojure.data.json :as json]
-            [mertonon.api.util :as api-util]
+  (:require [mertonon.api.util :as api-util]
             [mertonon.models.cost-object :as cost-object-model]
             [mertonon.models.entry :as entry-model]
             [mertonon.models.input :as input-model]
@@ -41,7 +40,7 @@
                             :entries        (sort-by :uuid entries)
                             :src-weightsets src-weightsets
                             :tgt-weightsets tgt-weightsets}]
-    {:status 200 :body (json/write-str body-res)}))
+    {:status 200 :body body-res}))
 
 (defn view-endpoint []
   {:get cost-object-view-get :name ::cost-object-view})

--- a/src/mertonon/api/entry.clj
+++ b/src/mertonon/api/entry.clj
@@ -1,7 +1,6 @@
 (ns mertonon.api.entry
   "API for entries"
-  (:require [clojure.data.json :as json]
-            [mertonon.api.util :as api-util]
+  (:require [mertonon.api.util :as api-util]
             [mertonon.models.entry :as entry-model]
             [mertonon.util.uuid :as uutils]))
 

--- a/src/mertonon/api/fe_test_generators.clj
+++ b/src/mertonon/api/fe_test_generators.clj
@@ -3,7 +3,6 @@
   Do not use for BE testing, use `mertonon.generators` stuff for that
   Do not use for demos, there's a `mertonon.api.generators` for that"
   (:require [clojure.core.matrix :as cm]
-            [clojure.data.json :as json]
             [clojure.test.check.generators :as gen]
             [loom.graph :as graph]
             [mertonon.generators.net :as net-gen]
@@ -16,7 +15,7 @@
 (defn grid-get [_]
   (let [res (->> (gen/sample net-gen/generate-grid)
                  (mapv :grids))]
-    {:status 200 :body (json/write-str res)}))
+    {:status 200 :body res}))
 
 (def fe-generated-grid-endpoint {:get grid-get :name ::fe-generated-grid-endpoint})
 
@@ -25,14 +24,14 @@
         res         (vec (for [net genned-nets
                                :let [graph (graph-service/net->graph (:layers net) (:weightsets net))]]
                            {:nodes (graph/nodes graph) :edges (graph/edges graph) :weightsets (:weightsets net)}))]
-    {:status 200 :body (json/write-str res)}))
+    {:status 200 :body res}))
 
 (def fe-generated-graph-endpoint {:get graph-get :name ::fe-generated-graph-endpoint})
 
 (defn loss-get [_]
   (let [res (->> (gen/sample net-gen/generate-dag-net)
                  (mapv #(select-keys % [:grids :losses])))]
-    {:status 200 :body (json/write-str res)}))
+    {:status 200 :body res}))
 
 (def fe-generated-loss-endpoint {:get loss-get :name ::fe-generated-loss-endpoint})
 

--- a/src/mertonon/api/generators.clj
+++ b/src/mertonon/api/generators.clj
@@ -3,7 +3,6 @@
   Do not use for FE testing, there's a `mertonon.api.fe-test-generators`
   for that which will give you multiple generates"
   (:require [clojure.core.matrix :as cm]
-            [clojure.data.json :as json]
             [clojure.test.check.generators :as gen]
             [loom.graph :as graph]
             [mertonon.generators.net :as net-gen]
@@ -73,7 +72,7 @@
   (let [[net patterns & _] @generated-net-atom
         entry-net          (assoc net :entries (sort-by :uuid (:entries patterns)))
         no-matrix-net      (dissoc entry-net :matrices)]
-    {:status 200 :body (json/write-str no-matrix-net)}))
+    {:status 200 :body no-matrix-net}))
 
 (def generated-net-endpoint
   {:get generated-net-get :name ::generated-net})
@@ -91,11 +90,11 @@
         grids      (:grids net)
         weightsets (:weightsets net)
         layers     (:layers net)]
-    {:status 200 :body (json/write-str {:grids      grids
-                                        :nodes      nodes
-                                        :edges      edges
-                                        :weightsets weightsets
-                                        :layers     layers})}))
+    {:status 200 :body {:grids      grids
+                        :nodes      nodes
+                        :edges      edges
+                        :weightsets weightsets
+                        :layers     layers}}))
 
 (def generated-net-graph-endpoint
   {:get generated-net-graph-get :name ::generated-net-graph})
@@ -118,7 +117,7 @@
                                          :src-weightsets src-weightsets
                                          :tgt-weightsets tgt-weightsets
                                          :cost-objects   cost-objects-with-grads}]
-     {:status 200 :body (json/write-str body-res)}))
+     {:status 200 :body body-res}))
 
 (def generated-net-layer-endpoint
   {:get generated-net-layer-get :name ::generated-net-layer})
@@ -145,7 +144,7 @@
                                          :entries        (or (sort-by :uuid ((:cobj->entries patterns) curr-uuid)) [])
                                          :src-weightsets src-weightsets
                                          :tgt-weightsets tgt-weightsets}]
-    {:status 200 :body (json/write-str body-res)}))
+    {:status 200 :body body-res}))
 
 (def generated-net-cost-object-endpoint
   {:get generated-net-cost-object-get :name ::generated-net-cost-object})
@@ -174,7 +173,7 @@
                       :weights   grad-weights
                       :src-cobjs src-cobjs
                       :tgt-cobjs tgt-cobjs}]
-    {:status 200 :body (json/write-str body-res)}))
+    {:status 200 :body body-res}))
 
 (def generated-net-weightset-endpoint
   {:get generated-net-weightset-get :name ::generated-net-weightset})
@@ -198,7 +197,7 @@
                    :src-cobj  src-cobj
                    :tgt-cobj  tgt-cobj
                    :weightset weightset}]
-    {:status 200 :body (json/write-str body-res)}))
+    {:status 200 :body body-res}))
 
 (def generated-net-weight-endpoint
   {:get generated-net-weight-get :name ::generated-net-weight})
@@ -215,7 +214,7 @@
         body-res  {:grids  grid
                    :losses losses
                    :inputs inputs}]
-    {:status 200 :body (json/write-str body-res)}))
+    {:status 200 :body body-res}))
 
 (def generated-net-grid-endpoint
   {:get generated-net-grid-get :name ::generated-net-grid})
@@ -226,7 +225,7 @@
 
 (defn generated-net-forward-get [_]
   (let [[_ _ forward & _] @generated-net-atom]
-    {:status 200 :body (json/write-str forward)}))
+    {:status 200 :body forward}))
 
 (def generated-net-forward-endpoint
   {:get generated-net-forward-get :name ::generated-net-forward})
@@ -237,7 +236,7 @@
 
 (defn generated-net-grad-get [_]
   (let [[_ patterns _ grad & _]   @generated-net-atom]
-    {:status 200 :body (json/write-str grad)}))
+    {:status 200 :body grad}))
 
 (def generated-net-grad-endpoint
   {:get generated-net-grad-get :name ::generated-net-grad})

--- a/src/mertonon/api/grid.clj
+++ b/src/mertonon/api/grid.clj
@@ -1,7 +1,6 @@
 (ns mertonon.api.grid
   "API for grids"
-  (:require [clojure.data.json :as json]
-            [clojure.walk :as walk]
+  (:require [clojure.walk :as walk]
             [loom.graph :as graph]
             [mertonon.api.util :as api-util]
             [mertonon.models.entry :as entry-model]
@@ -67,7 +66,7 @@
         grad                        (grad-service/forward-pass->grad forward-res)
         to-update                   (grad-service/grad->to-update grad)
         _                           (grad-service/update-grad-fields! to-update)]
-    {:status 200 :body (json/write-str (merge grad to-update))}))
+    {:status 200 :body (merge grad to-update)}))
 
 (defn grad-endpoint []
   {:post grad-create! :name ::grad-create})
@@ -92,9 +91,9 @@
                       :table->model     registry/table->model})
         entry-res   (->> entry-res :mertonon.entries (sort-by :uuid))
         net-res     (coarse-serde-service/db->net grid-uuid)]
-    {:status 200 :body (json/write-str (assoc net-res
-                                              :entries entry-res
-                                              :query params))}))
+    {:status 200 :body (assoc net-res
+                              :entries entry-res
+                              :query params)}))
 
 (defn dump-endpoint []
   {:get grid-dump-get :name ::grad-dump})
@@ -110,11 +109,11 @@
         net-graph    (graph-service/net->graph layers weightsets)
         nodes        (graph/nodes net-graph)
         edges        (graph/edges net-graph)]
-    {:status 200 :body (json/write-str {:grids      [grid]
-                                        :nodes      nodes
-                                        :layers     layers
-                                        :edges      edges
-                                        :weightsets weightsets})}))
+    {:status 200 :body {:grids      [grid]
+                        :nodes      nodes
+                        :layers     layers
+                        :edges      edges
+                        :weightsets weightsets}}))
 
 (defn graph-endpoint []
   {:get grid-graph-get :name ::grid-graph})
@@ -127,9 +126,9 @@
                        ((input-model/model :read-where) [:in :layer-uuid (mapv :uuid layers)]))
         losses       (if (empty? layers) []
                        ((loss-model/model :read-where) [:in :layer-uuid (mapv :uuid layers)]))]
-    {:status 200 :body (json/write-str {:grids  [grid]
-                                        :losses (sort-by :uuid losses)
-                                        :inputs (sort-by :uuid inputs)})}))
+    {:status 200 :body {:grids  [grid]
+                        :losses (sort-by :uuid losses)
+                        :inputs (sort-by :uuid inputs)}}))
 
 (defn view-endpoint []
   {:get grid-view-get :name ::grid-view})

--- a/src/mertonon/api/health_check.clj
+++ b/src/mertonon/api/health_check.clj
@@ -6,8 +6,7 @@
   Monitoring and QA are not fundamentally different things. Machine learning and testing are not formally different things.
 
   This poses authn and authz difficulties, but you would need to deal with those in any good faith testing anyways."
-  (:require [clojure.data.json :as json]
-            [mertonon.api.util :as api-util]
+  (:require [mertonon.api.util :as api-util]
             [mertonon.models.health-check :as hc-model]
             [mertonon.util.uuid :as uutils]))
 

--- a/src/mertonon/api/intro.clj
+++ b/src/mertonon/api/intro.clj
@@ -1,7 +1,6 @@
 (ns mertonon.api.intro
   "API for introduction to mertonon. After successful intro, should disable itself"
-  (:require [clojure.data.json :as json]
-            [clojure.walk :as walk]
+  (:require [clojure.walk :as walk]
             [mertonon.api.util :as api-util]
             [mertonon.models.constructors :as mtc]
             [mertonon.models.mt-session :as mt-session-model]
@@ -35,7 +34,7 @@
         res             {:mt-user mt-user!
                          :session (:uuid session!)}]
     {:status 200
-     :body (json/write-str res)}))
+     :body   res}))
 
 (defn intro-endpoint []
   {:post do-intro

--- a/src/mertonon/api/layer.clj
+++ b/src/mertonon/api/layer.clj
@@ -1,7 +1,6 @@
 (ns mertonon.api.layer
   "API for layers"
-  (:require [clojure.data.json :as json]
-            [mertonon.api.util :as api-util]
+  (:require [mertonon.api.util :as api-util]
             [mertonon.models.layer :as layer-model]
             [mertonon.models.weightset :as weightset-model]
             [mertonon.models.cost-object :as cost-object-model]
@@ -35,7 +34,7 @@
                             :src-weightsets src-weightsets
                             :tgt-weightsets tgt-weightsets
                             :cost-objects   cost-objects}]
-     {:status 200 :body (json/write-str body-res)}))
+     {:status 200 :body body-res}))
 
 (defn view-endpoint []
   {:get layer-view-get :name ::layer-view})

--- a/src/mertonon/api/login.clj
+++ b/src/mertonon/api/login.clj
@@ -1,7 +1,6 @@
 (ns mertonon.api.login
   "API for logging in. Not to be confused with password-login"
-  (:require [clojure.data.json :as json]
-            [clojure.walk :as walk]
+  (:require [clojure.walk :as walk]
             [mertonon.api.util :as api-util]
             [mertonon.models.constructors :as mtc]
             [mertonon.models.mt-user :as mt-user-model]
@@ -33,8 +32,7 @@
                          (:password body)
                          (->> user-q :mertonon.password-logins first :password-digest)))]
     (if (not is-valid?)
-      {:status 401 :body (json/write-str
-                           {:message "Login invalid somehow. Check the username and password."})}
+      {:status 401 :body {:message "Login invalid somehow. Check the username and password."}}
       (let [curr-user   (->> user-q :mertonon.mt-users first)
             curr-time   (t/instant)
             expiration  (t/>> curr-time (t/new-duration session-length-days :days))
@@ -47,7 +45,7 @@
          :cookies {:ring-session
                    {:value     (str (:uuid session-res))
                     :http-only true}}
-         :body    (json/write-str {})}))))
+         :body    {}}))))
 
 (defn login-endpoint []
   {:post do-login

--- a/src/mertonon/api/mt_user.clj
+++ b/src/mertonon/api/mt_user.clj
@@ -1,7 +1,6 @@
 (ns mertonon.api.mt-user
   "API for mertonon users."
-  (:require [clojure.data.json :as json]
-            [mertonon.api.util :as api-util]
+  (:require [mertonon.api.util :as api-util]
             [mertonon.models.mt-user :as mt-user-model]
             [mertonon.util.uuid :as uutils]))
 

--- a/src/mertonon/api/password_login.clj
+++ b/src/mertonon/api/password_login.clj
@@ -2,8 +2,7 @@
   "API for the separate table for the mertonon password auths corresponding to users.
 
   Not for directly logging in, but for doing CRUD for password logins"
-  (:require [clojure.data.json :as json]
-            [mertonon.api.util :as api-util]
+  (:require [mertonon.api.util :as api-util]
             [mertonon.models.password-login :as password-login-model]
             [mertonon.util.uuid :as uutils]))
 

--- a/src/mertonon/api/util.clj
+++ b/src/mertonon/api/util.clj
@@ -1,7 +1,6 @@
 (ns mertonon.api.util
   "API utilities"
-  (:require [clojure.data.json :as json]
-            [clojure.walk :as walk]
+  (:require [clojure.walk :as walk]
             [mertonon.util.io :as uio]
             [mertonon.util.uuid :as uutils]
             [taoensso.timbre :as timbre :refer [log]]
@@ -39,7 +38,7 @@
           res             (if (map? model-or-models)
                             ((curr-model :create-one!) model-or-models)
                             ((curr-model :create-many!) model-or-models))]
-      {:status 200 :body (json/write-str res)})))
+      {:status 200 :body res})))
 
 (defn get-models [curr-model]
   (fn [match]
@@ -47,24 +46,21 @@
           res       (if (empty? uuid-list)
                       ((curr-model :read-all))
                       ((curr-model :read-many) uuid-list))]
-      {:status 200 :body (json/write-str res)})))
+      {:status 200 :body res})))
 
 (defn get-model [curr-model]
   (fn [match]
     (let [curr-uuid (path-uuid match)]
-      {:status 200 :body (json/write-str
-                           ((curr-model :read-one) curr-uuid))})))
+      {:status 200 :body ((curr-model :read-one) curr-uuid)})))
 
 ;; TODO: update percolated up to API
 
 (defn delete-model [curr-model]
   (fn [match]
     (let [curr-uuid (path-uuid match)]
-      {:status 200 :body (json/write-str
-                           ((curr-model :hard-delete-one!) curr-uuid))})))
+      {:status 200 :body ((curr-model :hard-delete-one!) curr-uuid)})))
 
 (defn delete-models [curr-model]
   (fn [match]
     (let [curr-uuids (body-uuids match)]
-      {:status 200 :body (json/write-str
-                           ((curr-model :hard-delete-many!) curr-uuids))})))
+      {:status 200 :body ((curr-model :hard-delete-many!) curr-uuids)})))

--- a/src/mertonon/api/weight.clj
+++ b/src/mertonon/api/weight.clj
@@ -1,7 +1,6 @@
 (ns mertonon.api.weight
   "API for weights"
-  (:require [clojure.data.json :as json]
-            [mertonon.api.util :as api-util]
+  (:require [mertonon.api.util :as api-util]
             [mertonon.models.cost-object :as cost-object-model]
             [mertonon.models.weight :as weight-model]
             [mertonon.models.weightset :as weightset-model]
@@ -28,7 +27,7 @@
                      :src-cobj  src-cobj
                      :tgt-cobj  tgt-cobj
                      :weightset weightset}]
-    {:status 200 :body (json/write-str body-res)}))
+    {:status 200 :body body-res}))
 
 (defn view-endpoint []
   {:get weight-view-get :name ::weight-view})

--- a/src/mertonon/api/weightset.clj
+++ b/src/mertonon/api/weightset.clj
@@ -1,7 +1,6 @@
 (ns mertonon.api.weightset
   "API for weightsets"
-  (:require [clojure.data.json :as json]
-            [mertonon.api.util :as api-util]
+  (:require [mertonon.api.util :as api-util]
             [mertonon.models.cost-object :as cost-object-model]
             [mertonon.models.layer :as layer-model]
             [mertonon.models.weight :as weight-model]
@@ -33,7 +32,7 @@
                     :weights   weights
                     :src-cobjs src-cobjs
                     :tgt-cobjs tgt-cobjs}]
-     {:status 200 :body (json/write-str body-res)}))
+     {:status 200 :body body-res}))
 
 (defn view-endpoint []
   {:get weightset-view-get :name ::weightset-view})

--- a/src/mertonon/server/handler.clj
+++ b/src/mertonon/server/handler.clj
@@ -24,6 +24,8 @@
 (defn- base-router-middlewares []
   [params/wrap-params
    wrap-cookies
+   ;; muuntaja makes everything a wibbley wobbley binary stream so
+   ;; shove anything dealing with plain request response after it
    muuntaja/format-middleware
    mt-json-middleware/wrap-json
    ;; Note order matters.

--- a/src/mertonon/server/handler.clj
+++ b/src/mertonon/server/handler.clj
@@ -1,5 +1,6 @@
 (ns mertonon.server.handler
   (:require [mertonon.server.middleware.auth :as mt-auth-middleware]
+            [mertonon.server.middleware.json :as mt-json-middleware]
             [mertonon.server.middleware.session :as mt-session-middleware]
             [mertonon.server.routes :as routes]
             [mertonon.util.i18n :refer [trs]]
@@ -24,6 +25,7 @@
   [params/wrap-params
    wrap-cookies
    muuntaja/format-middleware
+   mt-json-middleware/wrap-json
    ;; Note order matters.
    ;; TODO: Tighten up origins
    [wrap-cors

--- a/src/mertonon/server/middleware/json.clj
+++ b/src/mertonon/server/middleware/json.clj
@@ -1,0 +1,13 @@
+(ns mertonon.server.middleware.json
+  "ring-json doesn't work with data.json, cheshire only. which is why this exists"
+  (:require [clojure.data.json :as json]
+            [ring.util.response :refer [content-type]]))
+
+(defn wrap-json
+  [handler]
+  (fn [request]
+    (let [resp         (handler request)
+          updated-resp (update-in resp [:body] json/write-str)]
+      (if (contains? (:headers updated-resp) "Content-Type")
+        updated-resp
+        (content-type updated-resp "application/json; charset=utf-8")))))

--- a/test/mertonon/api/intro_tests.clj
+++ b/test/mertonon/api/intro_tests.clj
@@ -44,7 +44,6 @@
         (and (= 200 (:status fst-intro!))
              (= fst-user (-> fst-intro! :body :mt-user :username))
              (nil? (-> fst-intro! :body :password))
-             ;; TODO: get validations to do 400's instead of 500's
              (= 500 (:status snd-intro!)))))))
 
 (comment (run-tests))

--- a/versioning.md
+++ b/versioning.md
@@ -1,3 +1,5 @@
 Mertonon uses MAJOR.WEEKLY.COMMITS where MAJOR is not semantic versioning but just a vague indication of size of changes. WEEKLY is incremented every week, reset to 0 upon new MAJOR version. COMMITS is total number of commits on repo, with each commit being a squashed PR. COMMITS is not to be reset to 0 ever.
 
+In the package.json for the yarn frontend build the build is given as MAJOR.WEEKLY.commits where _commits_ is literally just the string commits instead of the number of commits. This is because we are lazy and do not wish to update package.json separately except for the weekly and major versions.
+
 We will deploy every business Thursday, no exceptions. Whether that's a major or weekly version will depend upon our coffee supply, number of sunspots, the phase of the moon, the flight of birds, the omens written in the entrails, the path of the smoke as it escapes the thurible, etc etc. We may even literally crank out a weekly version with no actual changes, for the hell of it and to exercise the ol' CI/CD. We may speed up the deploy cadence but not slow it down.


### PR DESCRIPTION
Low money instructions seem vaguely interesting to look at for peeps. Elaborate on em a bit.

JSON `write-str` is being annoying. Whack em all and have a middleware sort out the results. Can't use the ring-json middleware because that one needs cheshire and we use the crap out of the weirder serializations data.json can do